### PR TITLE
Single quotes prevents expansion of $ in password

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
               --config "$(Pipeline.Workspace)\config\SignClient.json" `
               --filelist "$(Pipeline.Workspace)\config\filelist.txt" `
               --user "$(SignClientUser)" `
-              --secret "$(SignClientSecret)" `
+              --secret '$(SignClientSecret)' `
               --name "CodeSignDemo" `
               --description "CodeSignDemo" `
               --descriptionUrl "https://github.com/novotnyllc/CodeSignDemo"


### PR DESCRIPTION
If the password happens to contain a dollar sign ($) it'll get expanded to a variable value, which is correct. Single quote will prevent the expansion.